### PR TITLE
Need to specify string value for auth type option

### DIFF
--- a/src/palace_tools/cli/download_feed.py
+++ b/src/palace_tools/cli/download_feed.py
@@ -91,7 +91,7 @@ def download_opds(
     username: str = typer.Option(None, "--username", "-u", help="Username"),
     password: str = typer.Option(None, "--password", "-p", help="Password"),
     authentication: opds.AuthType = typer.Option(
-        opds.AuthType.NONE, "--auth", "-a", help="Authentication type"
+        opds.AuthType.NONE.value, "--auth", "-a", help="Authentication type"
     ),
     url: str = typer.Argument(..., help="URL of feed", metavar="URL"),
     output_file: Path = typer.Argument(
@@ -109,7 +109,7 @@ def download_opds1(
     username: str = typer.Option(None, "--username", "-u", help="Username"),
     password: str = typer.Option(None, "--password", "-p", help="Password"),
     authentication: opds.AuthType = typer.Option(
-        opds.AuthType.NONE, "--auth", "-a", help="Authentication type"
+        opds.AuthType.NONE.value, "--auth", "-a", help="Authentication type"
     ),
     url: str = typer.Argument(..., help="URL of feed", metavar="URL"),
     output_file: Path = typer.Argument(


### PR DESCRIPTION
I would have thought, based on the type of the arg, that you would need to specify the enum member as the value, but this causes the script to fail with:
```
Invalid value for '--auth' / '-a': <AuthType.NONE: 'none'> is not one of 'basic', 'oauth', 'none'.
```

Updating to use the enum value instead allows the script to run with the default.