### PR TITLE
Add `dump` and basic OPDS 1.x support for patron-bookshelf tool. (PP-2762)

### DIFF
--- a/src/palace_tools/cli/patron_bookshelf.py
+++ b/src/palace_tools/cli/patron_bookshelf.py
@@ -20,7 +20,9 @@ def main() -> None:
     run_typer_app_as_main(app)
 
 
-def conflicts_with_as_json(ctx: typer.Context, param: typer.Option, value: bool):
+def conflicts_with_as_json(
+    ctx: typer.Context, param: typer.Option, value: bool
+) -> bool:
     """Check for conflicts with the `as_json` option.
 
     Setting the `as_json` option to True is valid only with OPDSv2 feeds and
@@ -135,7 +137,6 @@ def patron_bookshelf(
         print_bookshelf_summary(bookshelf)
 
 
-
 async def fetch_bookshelf(
     *,
     username: str | None = None,
@@ -158,7 +159,9 @@ async def fetch_bookshelf(
             opds_server=opds_server,
             http_client=client,
         )
-        return await patron.fetch_patron_bookshelf(accept=opds.content_type(), http_client=client)
+        return await patron.fetch_patron_bookshelf(
+            accept=opds.content_type(), http_client=client
+        )
 
 
 if __name__ == "__main__":

--- a/src/palace_tools/cli/patron_bookshelf.py
+++ b/src/palace_tools/cli/patron_bookshelf.py
@@ -21,7 +21,7 @@ def main() -> None:
 
 
 def conflicts_with_as_json(
-    ctx: typer.Context, param: typer.Option, value: bool
+    ctx: typer.Context, param: typer.CallbackParam, value: bool
 ) -> bool:
     """Check for conflicts with the `as_json` option.
 

--- a/src/palace_tools/cli/patron_bookshelf.py
+++ b/src/palace_tools/cli/patron_bookshelf.py
@@ -3,9 +3,10 @@
 import asyncio
 import json
 
+import httpx
 import typer
 
-from palace_tools.constants import DEFAULT_REGISTRY_URL
+from palace_tools.constants import DEFAULT_REGISTRY_URL, OpdsEnum
 from palace_tools.models.api.opds2 import OPDS2Feed
 from palace_tools.models.internal.bookshelf import print_bookshelf_summary
 from palace_tools.roles.patron import authenticate
@@ -17,6 +18,25 @@ app = typer.Typer(rich_markup_mode="rich")
 
 def main() -> None:
     run_typer_app_as_main(app)
+
+
+def conflicts_with_as_json(ctx: typer.Context, param: typer.Option, value: bool):
+    """Check for conflicts with the `as_json` option.
+
+    Setting the `as_json` option to True is valid only with OPDSv2 feeds and
+    when a dump of the full bookshelf feed has NOT been requested.
+    """
+    if (option := param.name) != "as_json":
+        raise ValueError(
+            "Programming error: This callback should be specified only for the 'as_json' option."
+        )
+    if value is False:
+        return value
+    if ctx.params.get("as_dump") is True:
+        raise ValueError("The '--json' option cannot be used with the '--dump' option.")
+    if ctx.params.get("opds") != OpdsEnum.OPDS_2:
+        raise ValueError("The '--json' option can only be used with OPDSv2 feeds.")
+    return value
 
 
 @app.command(
@@ -67,16 +87,30 @@ def patron_bookshelf(
         help="An OPDS server endpoint URL.",
         rich_help_panel="Group 3: OPDS Server Heuristic",
     ),
+    opds: OpdsEnum = typer.Option(
+        OpdsEnum.OPDS_2,
+        "--opds",
+        help="Output format.",
+        rich_help_panel="Output",
+    ),
     as_json: bool = typer.Option(
         False,
         "--json",
         "-j",
         is_flag=True,
-        help="Output bookshelf as JSON.",
+        help="Output bookshelf as JSON. Incompatible with `--opds 1` and `--dump`.",
+        callback=conflicts_with_as_json,
+        rich_help_panel="Output",
+    ),
+    as_dump: bool = typer.Option(
+        False,
+        "--dump",
+        is_flag=True,
+        help="Output raw bookshelf response content.",
         rich_help_panel="Output",
     ),
 ) -> None:
-    bookshelf = asyncio.run(
+    response = asyncio.run(
         fetch_bookshelf(
             username=username,
             password=password,
@@ -85,12 +119,21 @@ def patron_bookshelf(
             opds_server=opds_server,
             auth_doc_url=auth_doc_url,
             allow_hidden_libraries=allow_hidden_libraries,
+            opds=opds,
         )
     )
+    # For the moment, OPDS v1 feeds can only be dumped. So, requesting either
+    # and OPDSv1 feed or a dump will produce only a dump.
+    if as_dump or opds == OpdsEnum.OPDS_1:
+        print(response.text)
+        return
+    # If we get this far, we have an OPDSv2 feed and should validate it.
+    bookshelf = OPDS2Feed.model_validate(response.json())
     if as_json:
-        print(json.dumps(bookshelf.dict(), indent=2))
+        print(json.dumps(bookshelf.model_dump(), indent=2))
     else:
         print_bookshelf_summary(bookshelf)
+
 
 
 async def fetch_bookshelf(
@@ -102,7 +145,8 @@ async def fetch_bookshelf(
     opds_server: str | None = None,
     auth_doc_url: str | None = None,
     allow_hidden_libraries: bool = False,
-) -> OPDS2Feed:
+    opds: OpdsEnum = OpdsEnum.OPDS_2,
+) -> httpx.Response:
     async with HTTPXAsyncClient() as client:
         patron = await authenticate(
             username=username,
@@ -114,7 +158,7 @@ async def fetch_bookshelf(
             opds_server=opds_server,
             http_client=client,
         )
-        return await patron.patron_bookshelf(http_client=client)
+        return await patron.fetch_patron_bookshelf(accept=opds.content_type(), http_client=client)
 
 
 if __name__ == "__main__":

--- a/src/palace_tools/constants.py
+++ b/src/palace_tools/constants.py
@@ -1,4 +1,6 @@
 # Some defaults
+from enum import StrEnum
+
 DEFAULT_ASYNC_TIMEOUT = 30.0
 DEFAULT_AUTH_DOC_PATH_SUFFIX = "authentication_document"
 DEFAULT_REGISTRY_URL = "https://registry.thepalaceproject.org"
@@ -13,6 +15,7 @@ OPDS_ACQ_OPEN_ACCESS_REL = "http://opds-spec.org/acquisition/open-access"
 OPDS_AUTH_DOC_REL = "http://opds-spec.org/auth/document"
 OPDS_AUTH_DOC_TYPE = "application/vnd.opds.authentication.v1.0+json"
 OPDS_REVOKE_REL = "http://librarysimplified.org/terms/rel/revoke"
+OPDS_1_TYPE = "application/atom+xml"
 OPDS_2_TYPE = "application/opds+json"
 
 
@@ -22,3 +25,17 @@ PATRON_BOOKSHELF_REL = "http://opds-spec.org/shelf"
 PATRON_BOOKSHELF_TYPE = "application/atom+xml;profile=opds-catalog;kind=acquisition"
 PATRON_PROFILE_REL = "http://librarysimplified.org/terms/rel/user-profile"
 PATRON_PROFILE_TYPE = "vnd.librarysimplified/user-profile+json"
+
+
+class OpdsEnum(StrEnum):
+    OPDS_1 = "1"
+    OPDS_2 = "2"
+
+    def content_type(self) -> str:
+        match self:
+            case OpdsEnum.OPDS_1:
+                return OPDS_1_TYPE
+            case OpdsEnum.OPDS_2:
+                return OPDS_2_TYPE
+        # Make `mypy` happy, since it thinks the list isn't exhaustive.
+        assert False

--- a/src/palace_tools/constants.py
+++ b/src/palace_tools/constants.py
@@ -1,5 +1,12 @@
+import sys
+
+if sys.version_info < (3, 11):
+    from backports.strenum import StrEnum
+else:
+    from enum import StrEnum
+
+
 # Some defaults
-from enum import StrEnum
 
 DEFAULT_ASYNC_TIMEOUT = 30.0
 DEFAULT_AUTH_DOC_PATH_SUFFIX = "authentication_document"

--- a/src/palace_tools/roles/patron.py
+++ b/src/palace_tools/roles/patron.py
@@ -9,7 +9,6 @@ from httpx import Response
 from palace_tools.constants import (
     DEFAULT_AUTH_DOC_PATH_SUFFIX,
     DEFAULT_REGISTRY_URL,
-    OPDS_1_TYPE,
     OPDS_2_TYPE,
     PATRON_AUTH_BASIC_TOKEN_TYPE,
     PATRON_AUTH_BASIC_TYPE,
@@ -18,7 +17,7 @@ from palace_tools.models.api.authentication_document import (
     AuthenticationDocument,
     AuthenticationMechanism,
 )
-from palace_tools.models.api.opds2 import OPDS2Feed, match_links
+from palace_tools.models.api.opds2 import match_links
 from palace_tools.models.api.patron_profile import PatronProfileDocument
 from palace_tools.services.registry import LibraryRegistryService
 from palace_tools.utils.http.async_client import HTTPXAsyncClient, validate_response
@@ -58,7 +57,9 @@ class AuthenticatedPatron(PatronAuthorization):
         return PatronProfileDocument.model_validate(profile)
 
     async def fetch_patron_bookshelf(
-        self, accept: str = OPDS_2_TYPE, http_client: HTTPXAsyncClient | None = None,
+        self,
+        accept: str = OPDS_2_TYPE,
+        http_client: HTTPXAsyncClient | None = None,
     ) -> Response:
         [patron_bookshelf_link] = self.authentication_document.patron_bookshelf_links
         headers = dict(self.token.as_http_headers) | {"Accept": accept}


### PR DESCRIPTION
## Description

- Add `--dump` and `--opds <version>` options for the `patron-bookshelf` tool.

Run `patron-bookshelf --help` for help. The new options are listed in the "Output" section of the help.

## Motivation and Context

It is useful to be able to get a full dump of patron feeds.

[Jira PP-2672]

## How Has This Been Tested?

Manual testing in local development environment.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
