### PR TITLE
Add some additional OPDS validation options

### DIFF
--- a/src/palace_tools/feeds/opds.py
+++ b/src/palace_tools/feeds/opds.py
@@ -6,6 +6,7 @@ import sys
 from base64 import b64encode
 from collections.abc import Callable, Generator, Mapping
 from enum import Enum
+from pathlib import Path
 from typing import Any, NamedTuple, TextIO
 
 import httpx
@@ -222,3 +223,10 @@ def fetch(
             progress.update(download_task, advance=1)
 
     return feeds
+
+
+def load(input_file: Path) -> dict[str, dict[str, Any]]:
+    with input_file.open("r") as file:
+        url = f"file://{input_file.resolve()}"
+        contents = json.loads(file.read())
+    return {url: contents}

--- a/src/palace_tools/validation/opds.py
+++ b/src/palace_tools/validation/opds.py
@@ -1,5 +1,6 @@
 import json
 import textwrap
+from difflib import context_diff
 from typing import Any
 
 from pydantic import TypeAdapter, ValidationError
@@ -7,8 +8,46 @@ from pydantic import TypeAdapter, ValidationError
 from palace.manager.opds.opds2 import PublicationFeedNoValidation
 
 
+def _should_ignore_error(error: ValidationError, ignore_errors: list[str]) -> bool:
+    if not ignore_errors:
+        return False
+
+    for ignored in ignore_errors:
+        if ignored in str(error):
+            return True
+
+    return False
+
+
+def _diff_original_parsed(
+    feed: dict[str, Any], publication_feed: PublicationFeedNoValidation
+) -> list[str]:
+    return list(
+        context_diff(
+            json.dumps(
+                feed,
+                indent=2,
+                sort_keys=True,
+            ).splitlines(),
+            json.dumps(
+                publication_feed.model_dump(
+                    mode="json", exclude_unset=True, by_alias=True
+                ),
+                indent=2,
+                sort_keys=True,
+            ).splitlines(),
+            fromfile="original",
+            tofile="parsed",
+            lineterm="",
+        )
+    )
+
+
 def validate_opds_feeds(
-    feeds: dict[str, dict[str, Any]], publication_cls: Any
+    feeds: dict[str, dict[str, Any]],
+    publication_cls: Any,
+    ignore_errors: list[str],
+    display_diff: bool,
 ) -> list[str]:
     errors = []
     publication_adapter = TypeAdapter(publication_cls)
@@ -16,17 +55,42 @@ def validate_opds_feeds(
     for url, feed in feeds.items():
         try:
             publication_feed = PublicationFeedNoValidation.model_validate(feed)
+
+            if display_diff:
+                diff = _diff_original_parsed(feed, publication_feed)
+                if diff:
+                    errors.append(f"Feed JSON differs from parsed model:")
+                    errors.append(f"  URL: {url}")
+                    errors.append(
+                        "\n".join(textwrap.indent(line, "    ") for line in diff)
+                    )
         except ValidationError as e:
-            errors.append(f"Error validating feed page.")
-            errors.append(f"  URL: {url}")
-            errors.append(f"  Errors:")
-            errors.append(textwrap.indent(str(e), "    "))
+            if not _should_ignore_error(e, ignore_errors):
+                # If the error is not in the ignore list, we log it
+                errors.append(f"Error validating feed page.")
+                errors.append(f"  URL: {url}")
+                errors.append(f"  Errors:")
+                errors.append(textwrap.indent(str(e), "    "))
             continue
 
         for publication_dict in publication_feed.publications:
             try:
-                publication_adapter.validate_python(publication_dict)
+                publication = publication_adapter.validate_python(publication_dict)
+
+                if display_diff:
+                    diff = _diff_original_parsed(publication_dict, publication)
+                    if diff:
+                        errors.append(f"Publication JSON differs from parsed model:")
+                        errors.append(
+                            f"  Identifier: {publication.metadata.identifier}"
+                        )
+                        errors.append(
+                            "\n".join(textwrap.indent(line, "    ") for line in diff)
+                        )
             except ValidationError as e:
+                if _should_ignore_error(e, ignore_errors):
+                    continue
+
                 metadata_dict = publication_dict.get("metadata", {})
 
                 # Extract any information we can from metadata_dict, to help with error message


### PR DESCRIPTION
Add some additional options for OPDS2 validation that I've found helpful:
- Ability to validate a feed from a local json file
- Ability to ignore some feed errors (helpful when validation a feed with some known errors, to make sure other errors aren't present).
- Ability to output a the diff between the input json and the parsed json (helpful to see: things that may be parsed incorrectly, attributes that are not being recognized by the parser)