### PR TITLE
Add -z/--skip-not-found option to overdrive download tool to skip url…

### DIFF
--- a/src/palace_tools/cli/download_feed.py
+++ b/src/palace_tools/cli/download_feed.py
@@ -72,6 +72,9 @@ def download_overdrive(
     output_file: Path = typer.Argument(
         ..., help="Output file", writable=True, file_okay=True, dir_okay=False
     ),
+    skip_not_found: bool = typer.Option(
+        False, "-z", "--skip-not-found", help="Skip any urls that are not found (404)"
+    ),
 ) -> None:
     """Download Overdrive feed."""
     base_url = overdrive.QA_BASE_URL if qa_endpoint else overdrive.PROD_BASE_URL
@@ -85,6 +88,7 @@ def download_overdrive(
             fetch_metadata,
             fetch_availability,
             connections,
+            skip_not_found,
         )
     )
 

--- a/src/palace_tools/feeds/overdrive.py
+++ b/src/palace_tools/feeds/overdrive.py
@@ -133,6 +133,7 @@ async def fetch(
     fetch_metadata: bool,
     fetch_availability: bool,
     connections: int,
+    skip_not_found: bool,
 ) -> list[dict[str, Any]]:
     async with httpx.AsyncClient(
         timeout=Timeout(20.0, pool=None),
@@ -210,10 +211,13 @@ async def fetch(
                             print("Too many retries. Exiting.")
                             sys.exit(-1)
                         else:
-                            print(
-                                f"Retrying request (attempt {retried_requests[request_url]}/3)"
-                            )
-                            urls.appendleft(request_url)
+                            if skip_not_found and ("404 Not Found") in str(e):
+                                print(f'url "{e.request.url}" NOT FOUND. Skipping...')
+                            else:
+                                print(
+                                    f"Retrying request (attempt {retried_requests[request_url]}/3)"
+                                )
+                                urls.appendleft(request_url)
                     if urls:
                         make_request(client, urls, pending_requests)
 


### PR DESCRIPTION
…s that are not found.

This feature will prevent the download from failing if one of the links returns a 404 which is common when there are thousand of products int he overdrive feed.