### PR TITLE
Publish palace-tools to PyPI on release (PP-3973)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,47 @@
+name: Publish to PyPI
+
+# Publishes `palace-tools` to PyPI when a GitHub Release is published,
+# using PyPI's Trusted Publishing (OIDC) flow.
+# https://docs.pypi.org/trusted-publishers/
+#
+# No action is needed on new releases beyond publishing a GitHub Release
+# with a tag that hatch-vcs can parse as a version (e.g. `v1.0.0`).
+
+on:
+  release:
+    types: [published]
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  publish:
+    name: Publish palace-tools to PyPI
+    runs-on: ubuntu-24.04
+    permissions:
+      # Required for PyPI Trusted Publishing (OIDC).
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          # hatch-vcs needs the full tag history.
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          print-hash: true

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.envrc
+
+# hatch-vcs generated
+src/palace_tools/_version.py
 
 # Caches
 .*_cache

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ uv python install 3.12
 
 ## Installation
 
-This package is not currently available oon PyPI, but it can be installed and run locally in a couple of
-different ways, depending on your needs.
+This package is [published to PyPI](https://pypi.org/project/palace-tools/), and can also be
+installed and run locally from a clone of the repository.
 
 ### Installing the CLI Tools globally with `pipx`
 
@@ -77,11 +77,12 @@ If you don't already have `pipx` installed, you can get installation instruction
 [here](https://github.com/pypa/pipx?tab=readme-ov-file#install-pipx).
 
 ```shell
-pipx install git+https://github.com/ThePalaceProject/palace-tools.git
+pipx install palace-tools
 ```
 
-or, if you wish to install a particular branch or commit, you can do something like this
-(more details about [installing from VCS here](https://github.com/pypa/pipx?tab=readme-ov-file#installing-from-source-control)):
+Alternatively, you can install directly from the git repository, for example to try a
+particular branch or commit (more details about
+[installing from VCS here](https://github.com/pypa/pipx?tab=readme-ov-file#installing-from-source-control)):
 
 ```shell
 pipx install git+https://github.com/ThePalaceProject/palace-tools.git@branch-or-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ validate-feed = "palace_tools.cli.validate_feed:main"
 Homepage = "https://thepalaceproject.org"
 Repository = "https://github.com/ThePalaceProject/palace-tools"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/palace_tools/_version.py"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/palace_tools"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling"]
+requires = ["hatch-vcs", "hatchling"]
 
 [dependency-groups]
 ci = [
@@ -32,11 +32,11 @@ dependencies = [
     "xmltodict>=1.0.2,<2",
 ]
 description = "Palace Tools"
+dynamic = ["version"]
 license = "Apache-2.0"
 name = "palace-tools"
 readme = "README.md"
 requires-python = ">=3.12,<4"
-version = "0"
 
 [project.scripts]
 audiobook-manifest-summary = "palace_tools.cli.summarize_rwpm_audio_manifest:main"
@@ -53,9 +53,13 @@ validate-feed = "palace_tools.cli.validate_feed:main"
 
 [project.urls]
 Homepage = "https://thepalaceproject.org"
+Repository = "https://github.com/ThePalaceProject/palace-tools"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/palace_tools"]
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.isort]
 known_palace = ["palace"]

--- a/src/palace_tools/__init__.py
+++ b/src/palace_tools/__init__.py
@@ -1,0 +1,9 @@
+__version__: str | None
+try:
+    from palace_tools._version import __version__
+except ImportError:
+    # This should only ever happen if uv sync wasn't run, but it's good
+    # to have a reasonable fallback in this case.
+    __version__ = None
+
+__all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,6 @@ wheels = [
 
 [[package]]
 name = "palace-tools"
-version = "0"
 source = { editable = "." }
 dependencies = [
     { name = "ddsketch" },


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that builds and publishes \`palace-tools\` to PyPI whenever a GitHub Release is published, via PyPI [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API tokens.
- Use [\`hatch-vcs\`](https://github.com/ofek/hatch-vcs) to derive the version from the git tag at build time; \`project.version\` becomes dynamic.
- Modeled on [circulation#3238](https://github.com/ThePalaceProject/circulation/pull/3238), but simpler: since palace-tools isn't a workspace and we're not already tied to dunamai, hatch-vcs reads the tag directly and avoids the committed \`_version.py\` stub / CI version-injection dance.

Cutting a release: publish a GitHub Release with a PEP 440-compatible tag (e.g. \`v1.0.0\`) and the workflow handles the rest.

## One-time setup required
~~Configure a [Trusted Publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) on PyPI.~~ This is done.

## Test plan
- [x] \`uv build\` locally produces wheel + sdist with a hatch-vcs-derived version
- [x] \`uv run mypy\` clean; \`uv run pytest\` (154 tests) passes
- [ ] Cut a test release after merge to confirm the workflow publishes successfully