### PR TITLE
Download and validate OPDS2+ODL License Info Documents (PP-4213)

### DIFF
--- a/src/palace/tools/cli/download_feed.py
+++ b/src/palace/tools/cli/download_feed.py
@@ -131,10 +131,7 @@ def download_opds(
 ) -> None:
     """Download OPDS 2 feed."""
     feeds = opds.fetch(url, username, password, authentication)
-    publications = []
-    for feed in feeds.values():
-        # Convert the feed to a list of publications
-        publications.extend(feed.get("publications", []))
+    publications = opds.all_publications(feeds)
 
     with output_file.open("w") as file:
         opds.write_json(file, publications)
@@ -168,9 +165,7 @@ def download_opds2_odl(
 ) -> None:
     """Download OPDS 2 + ODL feed including License Info Documents."""
     feeds = opds.fetch(url, username, password, authentication)
-    publications = []
-    for feed in feeds.values():
-        publications.extend(feed.get("publications", []))
+    publications = opds.all_publications(feeds)
 
     if license_documents:
         asyncio.run(

--- a/src/palace/tools/cli/download_feed.py
+++ b/src/palace/tools/cli/download_feed.py
@@ -6,7 +6,7 @@ from xml.dom import minidom
 import typer
 import xmltodict
 
-from palace.tools.feeds import axis, opds, opds1, overdrive
+from palace.tools.feeds import axis, odl, opds, opds1, overdrive
 from palace.tools.utils.typer import run_typer_app_as_main
 
 app = typer.Typer()
@@ -135,6 +135,54 @@ def download_opds(
     for feed in feeds.values():
         # Convert the feed to a list of publications
         publications.extend(feed.get("publications", []))
+
+    with output_file.open("w") as file:
+        opds.write_json(file, publications)
+
+
+@app.command("opds2-odl")
+def download_opds2_odl(
+    username: str = typer.Option(None, "--username", "-u", help="Username"),
+    password: str = typer.Option(None, "--password", "-p", help="Password"),
+    authentication: opds.AuthType = typer.Option(
+        opds.AuthType.NONE.value, "--auth", "-a", help="Authentication type"
+    ),
+    license_documents: bool = typer.Option(
+        True,
+        "--license-documents/--no-license-documents",
+        help=(
+            "Fetch the License Info Document for each license and embed it "
+            "under a 'license_document' key on the license."
+        ),
+    ),
+    connections: int = typer.Option(
+        20,
+        "-c",
+        "--connections",
+        help="Number of concurrent connections used to fetch License Info Documents.",
+    ),
+    url: str = typer.Argument(..., help="URL of feed", metavar="URL"),
+    output_file: Path = typer.Argument(
+        ..., help="Output file", writable=True, file_okay=True, dir_okay=False
+    ),
+) -> None:
+    """Download OPDS 2 + ODL feed including License Info Documents."""
+    feeds = opds.fetch(url, username, password, authentication)
+    publications = []
+    for feed in feeds.values():
+        publications.extend(feed.get("publications", []))
+
+    if license_documents:
+        asyncio.run(
+            odl.fetch_license_documents(
+                publications,
+                username=username,
+                password=password,
+                auth_type=authentication,
+                connections=connections,
+                base_url=url,
+            )
+        )
 
     with output_file.open("w") as file:
         opds.write_json(file, publications)

--- a/src/palace/tools/cli/validate_feed.py
+++ b/src/palace/tools/cli/validate_feed.py
@@ -3,7 +3,6 @@ import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
 import typer
 
@@ -85,12 +84,9 @@ def validate_opds2_odl(
     feeds = opds.fetch(url, username, password, authentication)
 
     if license_documents:
-        publications: list[dict[str, Any]] = []
-        for feed in feeds.values():
-            publications.extend(feed.get("publications", []))
         asyncio.run(
             odl.fetch_license_documents(
-                publications,
+                opds.all_publications(feeds),
                 username=username,
                 password=password,
                 auth_type=authentication,

--- a/src/palace/tools/cli/validate_feed.py
+++ b/src/palace/tools/cli/validate_feed.py
@@ -13,7 +13,6 @@ from palace.opds.odl import odl as odl_models
 from palace.tools.feeds import odl, opds
 from palace.tools.utils.typer import run_typer_app_as_main
 from palace.tools.validation.opds import (
-    validate_license_documents,
     validate_opds_feeds,
     validate_opds_publications,
 )
@@ -85,41 +84,30 @@ def validate_opds2_odl(
     """Validate OPDS 2 + ODL feed."""
     feeds = opds.fetch(url, username, password, authentication)
 
-    def run_validation() -> list[str]:
-        results = validate_opds_feeds(
-            feeds,
-            odl_models.Opds2OrOpds2WithOdlPublication,
-            ignore,
-            diff,
-            capture_warnings=not no_warnings,
+    if license_documents:
+        publications: list[dict[str, Any]] = []
+        for feed in feeds.values():
+            publications.extend(feed.get("publications", []))
+        asyncio.run(
+            odl.fetch_license_documents(
+                publications,
+                username=username,
+                password=password,
+                auth_type=authentication,
+                connections=connections,
+                base_url=url,
+            )
         )
 
-        if license_documents:
-            publications: list[dict[str, Any]] = []
-            for feed in feeds.values():
-                publications.extend(feed.get("publications", []))
-            asyncio.run(
-                odl.fetch_license_documents(
-                    publications,
-                    username=username,
-                    password=password,
-                    auth_type=authentication,
-                    connections=connections,
-                    base_url=url,
-                )
-            )
-            results.extend(
-                validate_license_documents(
-                    publications,
-                    ignore_errors=ignore,
-                    display_diff=diff,
-                    capture_warnings=not no_warnings,
-                )
-            )
-
-        return results
-
-    validate(output_file, run_validation)
+    validate(
+        output_file,
+        validate_opds_feeds,
+        feeds,
+        odl_models.Opds2OrOpds2WithOdlPublication,
+        ignore_errors=ignore,
+        display_diff=diff,
+        capture_warnings=not no_warnings,
+    )
 
 
 @app.command("opds2")

--- a/src/palace/tools/cli/validate_feed.py
+++ b/src/palace/tools/cli/validate_feed.py
@@ -1,16 +1,22 @@
+import asyncio
 import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import typer
 
 from palace.opds import opds2
-from palace.opds.odl import odl
+from palace.opds.odl import odl as odl_models
 
-from palace.tools.feeds import opds
+from palace.tools.feeds import odl, opds
 from palace.tools.utils.typer import run_typer_app_as_main
-from palace.tools.validation.opds import validate_opds_feeds, validate_opds_publications
+from palace.tools.validation.opds import (
+    validate_license_documents,
+    validate_opds_feeds,
+    validate_opds_publications,
+)
 
 app = typer.Typer()
 
@@ -52,6 +58,20 @@ def validate_opds2_odl(
     no_warnings: bool = typer.Option(
         False, "--no-warnings", help="Disable capturing and displaying parser warnings."
     ),
+    license_documents: bool = typer.Option(
+        True,
+        "--license-documents/--no-license-documents",
+        help=(
+            "Fetch and validate the License Info Document for each license. "
+            "Enabled by default."
+        ),
+    ),
+    connections: int = typer.Option(
+        20,
+        "-c",
+        "--connections",
+        help="Number of concurrent connections used to fetch License Info Documents.",
+    ),
     url: str = typer.Argument(..., help="URL of feed", metavar="URL"),
     output_file: Path = typer.Argument(
         None,
@@ -64,15 +84,42 @@ def validate_opds2_odl(
 ) -> None:
     """Validate OPDS 2 + ODL feed."""
     feeds = opds.fetch(url, username, password, authentication)
-    validate(
-        output_file,
-        validate_opds_feeds,
-        feeds,
-        odl.Opds2OrOpds2WithOdlPublication,
-        ignore,
-        diff,
-        capture_warnings=not no_warnings,
-    )
+
+    def run_validation() -> list[str]:
+        results = validate_opds_feeds(
+            feeds,
+            odl_models.Opds2OrOpds2WithOdlPublication,
+            ignore,
+            diff,
+            capture_warnings=not no_warnings,
+        )
+
+        if license_documents:
+            publications: list[dict[str, Any]] = []
+            for feed in feeds.values():
+                publications.extend(feed.get("publications", []))
+            asyncio.run(
+                odl.fetch_license_documents(
+                    publications,
+                    username=username,
+                    password=password,
+                    auth_type=authentication,
+                    connections=connections,
+                    base_url=url,
+                )
+            )
+            results.extend(
+                validate_license_documents(
+                    publications,
+                    ignore_errors=ignore,
+                    display_diff=diff,
+                    capture_warnings=not no_warnings,
+                )
+            )
+
+        return results
+
+    validate(output_file, run_validation)
 
 
 @app.command("opds2")

--- a/src/palace/tools/feeds/odl.py
+++ b/src/palace/tools/feeds/odl.py
@@ -80,15 +80,6 @@ async def fetch_license_documents(
                 "Fetching License Info Documents", total=len(targets)
             )
 
-            # Warm up auth with a single sequential request so concurrent
-            # workers don't all race to refresh the token.
-            warmup_pub, warmup_license, warmup_href = targets[0]
-            warmup_url = urljoin(base_url, warmup_href)
-            warmup_license[LICENSE_DOCUMENT_KEY] = await request_with_retry_async(
-                client, warmup_url
-            )
-            progress.update(task_id, advance=1)
-
             semaphore = asyncio.Semaphore(connections)
 
             async def worker(license_: dict[str, Any], href: str) -> None:
@@ -99,4 +90,4 @@ async def fetch_license_documents(
                     )
                     progress.update(task_id, advance=1)
 
-            await asyncio.gather(*(worker(lic, href) for _, lic, href in targets[1:]))
+            await asyncio.gather(*(worker(lic, href) for _, lic, href in targets))

--- a/src/palace/tools/feeds/odl.py
+++ b/src/palace/tools/feeds/odl.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import sys
 from collections.abc import Iterator
-from json import JSONDecodeError
 from typing import Any
 from urllib.parse import urljoin
 
@@ -14,9 +13,9 @@ from rich.progress import MofNCompleteColumn, Progress, SpinnerColumn
 from palace.opds.odl.info import LicenseInfo
 
 from palace.tools.feeds import opds
+from palace.tools.feeds.retry import request_with_retry_async
 
 LICENSE_DOCUMENT_KEY = "license_document"
-_RETRY_LIMIT = 3
 
 
 def iter_license_info_links(
@@ -37,40 +36,6 @@ def iter_license_info_links(
                 ):
                     yield publication, license_, link["href"]
                     break
-
-
-async def _fetch_one(client: httpx.AsyncClient, url: str) -> dict[str, Any]:
-    last_error: str = ""
-    for attempt in range(1, _RETRY_LIMIT + 1):
-        try:
-            response = await client.get(url)
-        except httpx.RequestError as e:
-            last_error = f"Request error: {e}"
-            print(f"License Info fetch error ({attempt}/{_RETRY_LIMIT}): {e} [{url}]")
-            continue
-
-        if response.status_code != 200:
-            last_error = f"Status code: {response.status_code}\nBody: {response.text}"
-            print(
-                f"License Info fetch error ({attempt}/{_RETRY_LIMIT}): "
-                f"{response.status_code} [{url}]"
-            )
-            continue
-
-        try:
-            return response.json()  # type: ignore[no-any-return]
-        except JSONDecodeError as e:
-            last_error = f"JSON decode error: {e}\nBody: {response.text}"
-            print(
-                f"License Info JSON decode error ({attempt}/{_RETRY_LIMIT}): "
-                f"{e} [{url}]"
-            )
-            continue
-
-    print(f"Failed to fetch License Info Document after {_RETRY_LIMIT} attempts.")
-    print(f"URL: {url}")
-    print(last_error)
-    sys.exit(-1)
 
 
 async def fetch_license_documents(
@@ -128,7 +93,9 @@ async def fetch_license_documents(
             # workers don't all race to refresh the token.
             warmup_pub, warmup_license, warmup_href = targets[0]
             warmup_url = urljoin(base_url, warmup_href)
-            warmup_license[LICENSE_DOCUMENT_KEY] = await _fetch_one(client, warmup_url)
+            warmup_license[LICENSE_DOCUMENT_KEY] = await request_with_retry_async(
+                client, warmup_url
+            )
             progress.update(task_id, advance=1)
 
             semaphore = asyncio.Semaphore(connections)
@@ -136,7 +103,9 @@ async def fetch_license_documents(
             async def worker(license_: dict[str, Any], href: str) -> None:
                 async with semaphore:
                     full_url = urljoin(base_url, href)
-                    license_[LICENSE_DOCUMENT_KEY] = await _fetch_one(client, full_url)
+                    license_[LICENSE_DOCUMENT_KEY] = await request_with_retry_async(
+                        client, full_url
+                    )
                     progress.update(task_id, advance=1)
 
             await asyncio.gather(*(worker(lic, href) for _, lic, href in targets[1:]))

--- a/src/palace/tools/feeds/odl.py
+++ b/src/palace/tools/feeds/odl.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Iterator
+from json import JSONDecodeError
+from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+from httpx import Limits, Timeout
+from rich.progress import MofNCompleteColumn, Progress, SpinnerColumn
+
+from palace.opds.odl.info import LicenseInfo
+
+from palace.tools.feeds import opds
+
+LICENSE_DOCUMENT_KEY = "license_document"
+_RETRY_LIMIT = 3
+
+
+def iter_license_info_links(
+    publications: list[dict[str, Any]],
+) -> Iterator[tuple[dict[str, Any], dict[str, Any], str]]:
+    """Yield ``(publication, license, info_url)`` for every License Info self link."""
+    info_content_type = LicenseInfo.content_type()
+    for publication in publications:
+        licenses = publication.get("licenses")
+        if not licenses:
+            continue
+        for license_ in licenses:
+            for link in license_.get("links", []):
+                if (
+                    link.get("rel") == "self"
+                    and link.get("type") == info_content_type
+                    and link.get("href")
+                ):
+                    yield publication, license_, link["href"]
+                    break
+
+
+async def _fetch_one(client: httpx.AsyncClient, url: str) -> dict[str, Any]:
+    last_error: str = ""
+    for attempt in range(1, _RETRY_LIMIT + 1):
+        try:
+            response = await client.get(url)
+        except httpx.RequestError as e:
+            last_error = f"Request error: {e}"
+            print(f"License Info fetch error ({attempt}/{_RETRY_LIMIT}): {e} [{url}]")
+            continue
+
+        if response.status_code != 200:
+            last_error = f"Status code: {response.status_code}\nBody: {response.text}"
+            print(
+                f"License Info fetch error ({attempt}/{_RETRY_LIMIT}): "
+                f"{response.status_code} [{url}]"
+            )
+            continue
+
+        try:
+            return response.json()  # type: ignore[no-any-return]
+        except JSONDecodeError as e:
+            last_error = f"JSON decode error: {e}\nBody: {response.text}"
+            print(
+                f"License Info JSON decode error ({attempt}/{_RETRY_LIMIT}): "
+                f"{e} [{url}]"
+            )
+            continue
+
+    print(f"Failed to fetch License Info Document after {_RETRY_LIMIT} attempts.")
+    print(f"URL: {url}")
+    print(last_error)
+    sys.exit(-1)
+
+
+async def fetch_license_documents(
+    publications: list[dict[str, Any]],
+    *,
+    username: str | None,
+    password: str | None,
+    auth_type: opds.AuthType,
+    connections: int,
+    base_url: str,
+) -> None:
+    """
+    Fetch the License Info Document for every license and embed each parsed
+    body in place on the license dict under :data:`LICENSE_DOCUMENT_KEY`.
+
+    Publications without a ``licenses`` field (plain OPDS 2 publications mixed
+    into an OPDS2+ODL feed) are skipped.
+    """
+    targets = list(iter_license_info_links(publications))
+    if not targets:
+        return
+
+    auth: httpx.Auth | None = None
+    if username and password:
+        if auth_type == opds.AuthType.BASIC:
+            auth = httpx.BasicAuth(username, password)
+        elif auth_type == opds.AuthType.OAUTH:
+            auth = opds.OAuthAuth(username, password, feed_url=base_url)
+    elif auth_type != opds.AuthType.NONE:
+        print("Username and password are required for authentication")
+        sys.exit(-1)
+
+    headers = {
+        "Accept": f"{LicenseInfo.content_type()}, application/json;q=0.9, */*;q=0.1",
+        "User-Agent": "Palace",
+    }
+
+    async with httpx.AsyncClient(
+        auth=auth,
+        headers=headers,
+        timeout=Timeout(30.0),
+        limits=Limits(
+            max_connections=connections,
+            max_keepalive_connections=connections,
+        ),
+    ) as client:
+        with Progress(
+            SpinnerColumn(), *Progress.get_default_columns(), MofNCompleteColumn()
+        ) as progress:
+            task_id = progress.add_task(
+                "Fetching License Info Documents", total=len(targets)
+            )
+
+            # Warm up auth with a single sequential request so concurrent
+            # workers don't all race to refresh the token.
+            warmup_pub, warmup_license, warmup_href = targets[0]
+            warmup_url = urljoin(base_url, warmup_href)
+            warmup_license[LICENSE_DOCUMENT_KEY] = await _fetch_one(client, warmup_url)
+            progress.update(task_id, advance=1)
+
+            semaphore = asyncio.Semaphore(connections)
+
+            async def worker(license_: dict[str, Any], href: str) -> None:
+                async with semaphore:
+                    full_url = urljoin(base_url, href)
+                    license_[LICENSE_DOCUMENT_KEY] = await _fetch_one(client, full_url)
+                    progress.update(task_id, advance=1)
+
+            await asyncio.gather(*(worker(lic, href) for _, lic, href in targets[1:]))

--- a/src/palace/tools/feeds/odl.py
+++ b/src/palace/tools/feeds/odl.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 from collections.abc import Iterator
 from typing import Any
 from urllib.parse import urljoin
@@ -58,15 +57,7 @@ async def fetch_license_documents(
     if not targets:
         return
 
-    auth: httpx.Auth | None = None
-    if username and password:
-        if auth_type == opds.AuthType.BASIC:
-            auth = httpx.BasicAuth(username, password)
-        elif auth_type == opds.AuthType.OAUTH:
-            auth = opds.OAuthAuth(username, password, feed_url=base_url)
-    elif auth_type != opds.AuthType.NONE:
-        print("Username and password are required for authentication")
-        sys.exit(-1)
+    auth = opds.build_auth(username, password, auth_type, feed_url=base_url)
 
     headers = {
         "Accept": f"{LicenseInfo.content_type()}, application/json;q=0.9, */*;q=0.1",

--- a/src/palace/tools/feeds/opds.py
+++ b/src/palace/tools/feeds/opds.py
@@ -166,12 +166,31 @@ def error_and_exit(response: httpx.Response, detail: str = "") -> None:
     sys.exit(-1)
 
 
-def make_request(session: httpx.Client, url: str) -> dict[str, Any]:
-    return request_with_retry_sync(session, url)
-
-
 def write_json(file: TextIO, data: list[dict[str, Any]]) -> None:
     file.write(json.dumps(data, indent=4))
+
+
+def build_auth(
+    username: str | None,
+    password: str | None,
+    auth_type: AuthType,
+    *,
+    feed_url: str,
+) -> httpx.Auth | None:
+    if username and password:
+        if auth_type == AuthType.BASIC:
+            return httpx.BasicAuth(username, password)
+        if auth_type == AuthType.OAUTH:
+            return OAuthAuth(username, password, feed_url=feed_url)
+        return None
+    if auth_type != AuthType.NONE:
+        print("Username and password are required for authentication")
+        sys.exit(-1)
+    return None
+
+
+def all_publications(feeds: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    return [pub for feed in feeds.values() for pub in feed.get("publications", [])]
 
 
 def fetch(
@@ -188,19 +207,14 @@ def fetch(
     )
     client.timeout = httpx.Timeout(30.0)
 
-    if username and password:
-        if auth_type == AuthType.BASIC:
-            client.auth = httpx.BasicAuth(username, password)
-        elif auth_type == AuthType.OAUTH:
-            client.auth = OAuthAuth(username, password, feed_url=url)
-    elif auth_type != AuthType.NONE:
-        print("Username and password are required for authentication")
-        sys.exit(-1)
+    auth = build_auth(username, password, auth_type, feed_url=url)
+    if auth is not None:
+        client.auth = auth
 
     feeds = {}
 
     # Get the first page
-    response = make_request(client, url)
+    response = request_with_retry_sync(client, url)
     items = response.get("metadata", {}).get("numberOfItems")
     items_per_page = response.get("metadata", {}).get("itemsPerPage")
 
@@ -216,7 +230,7 @@ def fetch(
     ) as progress:
         download_task = progress.add_task(f"Downloading Feed", total=pages)
         while next_url is not None:
-            response = make_request(client, next_url)
+            response = request_with_retry_sync(client, next_url)
             feeds[next_url] = response
             next_url = None
             for link in response["links"]:

--- a/src/palace/tools/feeds/opds.py
+++ b/src/palace/tools/feeds/opds.py
@@ -6,12 +6,13 @@ import sys
 from base64 import b64encode
 from collections.abc import Callable, Generator, Mapping
 from enum import Enum
-from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, NamedTuple, TextIO
 
 import httpx
 from rich.progress import MofNCompleteColumn, Progress, SpinnerColumn
+
+from palace.tools.feeds.retry import request_with_retry_sync
 
 
 class AuthType(Enum):
@@ -165,19 +166,8 @@ def error_and_exit(response: httpx.Response, detail: str = "") -> None:
     sys.exit(-1)
 
 
-def make_request(session: httpx.Client, url: str, retries: int = 0) -> dict[str, Any]:
-    response = session.get(url)
-    if response.status_code != 200:
-        if retries < 3:
-            print_error(response)
-            print(f"Retrying... ({retries + 1}/3)")
-            return make_request(session, url, retries + 1)
-        error_and_exit(response)
-    try:
-        return response.json()  # type: ignore[no-any-return]
-    except JSONDecodeError as e:
-        error_and_exit(response, str(e))
-        raise
+def make_request(session: httpx.Client, url: str) -> dict[str, Any]:
+    return request_with_retry_sync(session, url)
 
 
 def write_json(file: TextIO, data: list[dict[str, Any]]) -> None:

--- a/src/palace/tools/feeds/overdrive.py
+++ b/src/palace/tools/feeds/overdrive.py
@@ -5,11 +5,14 @@ import json
 import math
 import sys
 from collections import defaultdict, deque
+from json import JSONDecodeError
 from typing import Any
 
 import httpx
 from httpx import URL, HTTPStatusError, Limits, RequestError, Response, Timeout
 from rich.progress import MofNCompleteColumn, Progress, SpinnerColumn
+
+from palace.tools.feeds.retry import MAX_ATTEMPTS
 
 QA_BASE_URL = "https://integration.api.overdrive.com"
 PROD_BASE_URL = "https://api.overdrive.com"
@@ -209,6 +212,7 @@ async def fetch(
                 events_path = EVENTS_ENDPOINT % {"collection_token": collection_token}
 
                 for req in done:
+                    response: Response | None = None
                     try:
                         response = await req
                         process_request(
@@ -221,23 +225,31 @@ async def fetch(
                             urls,
                         )
                         progress.update(download_task, advance=1)
-                    except (RequestError, HTTPStatusError) as e:
-                        print(f"Request error: {e}")
-                        print(f"URL: {e.request.url}")
-                        request_url = str(e.request.url)
-                        retried_requests[request_url] += 1
-
-                        if retried_requests[request_url] > 3:
-                            print("Too many retries. Exiting.")
-                            sys.exit(-1)
+                    except (RequestError, HTTPStatusError, JSONDecodeError) as e:
+                        if isinstance(e, (RequestError, HTTPStatusError)):
+                            request_url = str(e.request.url)
                         else:
-                            if skip_not_found and ("404 Not Found") in str(e):
-                                print(f'url "{e.request.url}" NOT FOUND. Skipping...')
-                            else:
-                                print(
-                                    f"Retrying request (attempt {retried_requests[request_url]}/3)"
-                                )
-                                urls.appendleft(request_url)
+                            # JSONDecodeError: the await succeeded so response is set.
+                            assert response is not None
+                            request_url = str(response.url)
+                        retried_requests[request_url] += 1
+                        attempt = retried_requests[request_url]
+                        print(
+                            f"Request error ({attempt}/{MAX_ATTEMPTS}): {e} [{request_url}]"
+                        )
+
+                        if attempt >= MAX_ATTEMPTS:
+                            print(f"Giving up after {MAX_ATTEMPTS} attempts.")
+                            sys.exit(-1)
+
+                        if (
+                            skip_not_found
+                            and isinstance(e, HTTPStatusError)
+                            and e.response.status_code == 404
+                        ):
+                            print(f'url "{request_url}" NOT FOUND. Skipping...')
+                        else:
+                            urls.appendleft(request_url)
                     if urls:
                         make_request(client, urls, pending_requests)
 

--- a/src/palace/tools/feeds/retry.py
+++ b/src/palace/tools/feeds/retry.py
@@ -1,0 +1,80 @@
+"""Shared HTTP retry policy for feed downloads.
+
+Used by the OPDS, OPDS+ODL, and Overdrive feed clients. Retries on transient
+failures (network errors, non-200 responses, malformed JSON bodies) up to
+``MAX_ATTEMPTS`` total attempts (the initial request counts as attempt 1).
+On terminal failure the process exits with code ``-1``.
+"""
+
+from __future__ import annotations
+
+import sys
+from json import JSONDecodeError
+from typing import Any, NoReturn
+
+import httpx
+
+MAX_ATTEMPTS = 4
+
+
+def _log_attempt(url: str, attempt: int, detail: str) -> None:
+    print(f"Request error ({attempt}/{MAX_ATTEMPTS}): {detail} [{url}]")
+
+
+def _exit_after_retries(url: str, last_error: str) -> NoReturn:
+    print(f"Giving up after {MAX_ATTEMPTS} attempts.")
+    print(f"URL: {url}")
+    print(last_error)
+    sys.exit(-1)
+
+
+def request_with_retry_sync(client: httpx.Client, url: str) -> dict[str, Any]:
+    last_error = ""
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            response = client.get(url)
+        except httpx.RequestError as e:
+            last_error = f"Request error: {e}"
+            _log_attempt(url, attempt, str(e))
+            continue
+
+        if response.status_code != 200:
+            last_error = f"Status code: {response.status_code}\nBody: {response.text}"
+            _log_attempt(url, attempt, f"HTTP {response.status_code}")
+            continue
+
+        try:
+            return response.json()  # type: ignore[no-any-return]
+        except JSONDecodeError as e:
+            last_error = f"JSON decode error: {e}\nBody: {response.text}"
+            _log_attempt(url, attempt, f"JSON decode error: {e}")
+            continue
+
+    _exit_after_retries(url, last_error)
+
+
+async def request_with_retry_async(
+    client: httpx.AsyncClient, url: str
+) -> dict[str, Any]:
+    last_error = ""
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            response = await client.get(url)
+        except httpx.RequestError as e:
+            last_error = f"Request error: {e}"
+            _log_attempt(url, attempt, str(e))
+            continue
+
+        if response.status_code != 200:
+            last_error = f"Status code: {response.status_code}\nBody: {response.text}"
+            _log_attempt(url, attempt, f"HTTP {response.status_code}")
+            continue
+
+        try:
+            return response.json()  # type: ignore[no-any-return]
+        except JSONDecodeError as e:
+            last_error = f"JSON decode error: {e}\nBody: {response.text}"
+            _log_attempt(url, attempt, f"JSON decode error: {e}")
+            continue
+
+    _exit_after_retries(url, last_error)

--- a/src/palace/tools/validation/opds.py
+++ b/src/palace/tools/validation/opds.py
@@ -6,8 +6,10 @@ from typing import Any
 
 from pydantic import TypeAdapter, ValidationError
 
+from palace.opds.odl.info import LicenseInfo
 from palace.opds.opds2 import PublicationFeedNoValidation
 
+from palace.tools.feeds.odl import LICENSE_DOCUMENT_KEY, iter_license_info_links
 from palace.tools.utils.logging import LogCapture
 
 # Logger name for capturing OPDS parsing warnings
@@ -164,6 +166,143 @@ def validate_opds_publications(
                 continue
 
             errors.extend(_publication_issues(publication_dict, url, errors=str(e)))
+
+    return errors
+
+
+def _license_issues(
+    publication_dict: dict[str, Any],
+    license_dict: dict[str, Any],
+    license_doc: dict[str, Any],
+    info_url: str,
+    *,
+    errors: str | None = None,
+    warnings: str | None = None,
+    diff: str | None = None,
+) -> list[str]:
+    issues: list[str] = []
+    pub_metadata = publication_dict.get("metadata", {})
+    pub_identifier = pub_metadata.get("identifier", "<unknown>")
+    pub_title = pub_metadata.get("title", "<unknown>")
+    license_identifier = license_dict.get("metadata", {}).get("identifier", "<unknown>")
+
+    issue_types = []
+    if errors:
+        issue_types.append("ERROR")
+    if warnings:
+        issue_types.append("WARNING")
+    if diff:
+        issue_types.append("DIFF")
+
+    issues.append(
+        f"Validation failed for License Info Document. Issues: {', '.join(issue_types)}"
+    )
+    issues.append(f"  Publication identifier: {pub_identifier}")
+    issues.append(f"  Publication title: {pub_title!r}")
+    issues.append(f"  License identifier: {license_identifier}")
+    issues.append(f"  Info-doc URL: {info_url}")
+    if errors:
+        issues.append("  Errors:")
+        issues.append(textwrap.indent(errors, "    "))
+    if warnings:
+        issues.append("  Warnings:")
+        issues.append(textwrap.indent(warnings, "    "))
+    if diff:
+        issues.append("  License Info Document JSON differs from parsed model:")
+        issues.append(textwrap.indent(diff, "    "))
+    issues.append("  License Info Document JSON:")
+    issues.append(textwrap.indent(json.dumps(license_doc, indent=2), "    "))
+    return issues
+
+
+def validate_license_documents(
+    publications: list[dict[str, Any]],
+    *,
+    ignore_errors: list[str],
+    display_diff: bool,
+    capture_warnings: bool = True,
+) -> list[str]:
+    """
+    Validate every embedded License Info Document
+    (``license[LICENSE_DOCUMENT_KEY]``) against
+    :class:`palace.opds.odl.info.LicenseInfo`.
+
+    Licenses without an embedded document are skipped.
+    """
+    license_info_adapter = TypeAdapter(LicenseInfo)
+    errors: list[str] = []
+
+    log_capture = _setup_log_capture() if capture_warnings else None
+
+    info_urls: dict[int, str] = {
+        id(license_): info_url
+        for _, license_, info_url in iter_license_info_links(publications)
+    }
+
+    for publication in publications:
+        for license_ in publication.get("licenses") or []:
+            license_doc = license_.get(LICENSE_DOCUMENT_KEY)
+            if license_doc is None:
+                continue
+
+            info_url = info_urls.get(id(license_), "<unknown>")
+
+            if log_capture:
+                log_capture.clear()
+
+            try:
+                parsed = license_info_adapter.validate_python(license_doc)
+
+                warnings = "".join(log_capture.get_messages()) if log_capture else None
+
+                if display_diff:
+                    diff_lines = list(
+                        context_diff(
+                            json.dumps(
+                                license_doc, indent=2, sort_keys=True
+                            ).splitlines(),
+                            json.dumps(
+                                parsed.model_dump(
+                                    mode="json",
+                                    exclude_unset=True,
+                                    by_alias=True,
+                                ),
+                                indent=2,
+                                sort_keys=True,
+                            ).splitlines(),
+                            fromfile="original",
+                            tofile="parsed",
+                            lineterm="",
+                        )
+                    )
+                    diff = "\n".join(diff_lines) if diff_lines else None
+                else:
+                    diff = None
+
+                if diff or warnings:
+                    errors.extend(
+                        _license_issues(
+                            publication,
+                            license_,
+                            license_doc,
+                            info_url,
+                            warnings=warnings,
+                            diff=diff,
+                        )
+                    )
+            except ValidationError as e:
+                if _should_ignore_error(e, ignore_errors):
+                    continue
+
+                errors.extend(
+                    _license_issues(
+                        publication,
+                        license_,
+                        license_doc,
+                        info_url,
+                        errors=str(e),
+                    )
+                )
 
     return errors
 

--- a/src/palace/tools/validation/opds.py
+++ b/src/palace/tools/validation/opds.py
@@ -4,12 +4,12 @@ import textwrap
 from difflib import context_diff
 from typing import Any
 
-from pydantic import TypeAdapter, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from palace.opds.odl.info import LicenseInfo
 from palace.opds.opds2 import PublicationFeedNoValidation
 
-from palace.tools.feeds.odl import LICENSE_DOCUMENT_KEY, iter_license_info_links
+from palace.tools.feeds.odl import LICENSE_DOCUMENT_KEY
 from palace.tools.utils.logging import LogCapture
 
 # Logger name for capturing OPDS parsing warnings
@@ -27,20 +27,12 @@ def _should_ignore_error(error: ValidationError, ignore_errors: list[str]) -> bo
     return False
 
 
-def _diff_original_parsed(
-    feed: dict[str, Any], publication_feed: PublicationFeedNoValidation
-) -> list[str]:
+def _diff_original_parsed(original: dict[str, Any], parsed: BaseModel) -> list[str]:
     return list(
         context_diff(
+            json.dumps(original, indent=2, sort_keys=True).splitlines(),
             json.dumps(
-                feed,
-                indent=2,
-                sort_keys=True,
-            ).splitlines(),
-            json.dumps(
-                publication_feed.model_dump(
-                    mode="json", exclude_unset=True, by_alias=True
-                ),
+                parsed.model_dump(mode="json", exclude_unset=True, by_alias=True),
                 indent=2,
                 sort_keys=True,
             ).splitlines(),
@@ -123,51 +115,16 @@ def _setup_log_capture() -> LogCapture:
     return log_capture
 
 
-def validate_opds_publications(
-    publications: list[dict[str, Any]],
-    publication_cls: Any,
-    *,
-    url: str | None = None,
-    ignore_errors: list[str],
-    display_diff: bool,
-    capture_warnings: bool = True,
-) -> list[str]:
-    publication_adapter = TypeAdapter(publication_cls)
-    errors = []
-
-    log_capture = _setup_log_capture() if capture_warnings else None
-
-    for publication_dict in publications:
-        if log_capture:
-            log_capture.clear()
-
-        try:
-            publication = publication_adapter.validate_python(publication_dict)
-
-            # Check for captured warnings during parsing
-            warnings = "".join(log_capture.get_messages()) if log_capture else None
-
-            if display_diff:
-                diff = "\n".join(_diff_original_parsed(publication_dict, publication))
-            else:
-                diff = None
-
-            if diff or warnings:
-                errors.extend(
-                    _publication_issues(
-                        publication_dict,
-                        url,
-                        warnings=warnings,
-                        diff=diff,
-                    )
-                )
-        except ValidationError as e:
-            if _should_ignore_error(e, ignore_errors):
-                continue
-
-            errors.extend(_publication_issues(publication_dict, url, errors=str(e)))
-
-    return errors
+def _license_info_url(license_dict: dict[str, Any]) -> str:
+    info_content_type = LicenseInfo.content_type()
+    for link in license_dict.get("links") or []:
+        if (
+            link.get("rel") == "self"
+            and link.get("type") == info_content_type
+            and link.get("href")
+        ):
+            return link["href"]  # type: ignore[no-any-return]
+    return "<unknown>"
 
 
 def _license_issues(
@@ -181,10 +138,11 @@ def _license_issues(
     diff: str | None = None,
 ) -> list[str]:
     issues: list[str] = []
-    pub_metadata = publication_dict.get("metadata", {})
+    pub_metadata = publication_dict.get("metadata") or {}
     pub_identifier = pub_metadata.get("identifier", "<unknown>")
     pub_title = pub_metadata.get("title", "<unknown>")
-    license_identifier = license_dict.get("metadata", {}).get("identifier", "<unknown>")
+    license_metadata = license_dict.get("metadata") or {}
+    license_identifier = license_metadata.get("identifier", "<unknown>")
 
     issue_types = []
     if errors:
@@ -215,94 +173,115 @@ def _license_issues(
     return issues
 
 
-def validate_license_documents(
-    publications: list[dict[str, Any]],
+def _validate_license_document(
+    publication_dict: dict[str, Any],
+    license_dict: dict[str, Any],
+    license_doc: dict[str, Any],
+    license_info_adapter: TypeAdapter[LicenseInfo],
     *,
+    log_capture: LogCapture | None,
+    ignore_errors: list[str],
+    display_diff: bool,
+) -> list[str]:
+    info_url = _license_info_url(license_dict)
+
+    if log_capture:
+        log_capture.clear()
+
+    try:
+        parsed = license_info_adapter.validate_python(license_doc)
+    except ValidationError as e:
+        if _should_ignore_error(e, ignore_errors):
+            return []
+        return _license_issues(
+            publication_dict,
+            license_dict,
+            license_doc,
+            info_url,
+            errors=str(e),
+        )
+
+    warnings = "".join(log_capture.get_messages()) if log_capture else None
+
+    if display_diff:
+        diff_lines = _diff_original_parsed(license_doc, parsed)
+        diff = "\n".join(diff_lines) if diff_lines else None
+    else:
+        diff = None
+
+    if diff or warnings:
+        return _license_issues(
+            publication_dict,
+            license_dict,
+            license_doc,
+            info_url,
+            warnings=warnings,
+            diff=diff,
+        )
+    return []
+
+
+def validate_opds_publications(
+    publications: list[dict[str, Any]],
+    publication_cls: Any,
+    *,
+    url: str | None = None,
     ignore_errors: list[str],
     display_diff: bool,
     capture_warnings: bool = True,
 ) -> list[str]:
-    """
-    Validate every embedded License Info Document
-    (``license[LICENSE_DOCUMENT_KEY]``) against
-    :class:`palace.opds.odl.info.LicenseInfo`.
-
-    Licenses without an embedded document are skipped.
-    """
-    license_info_adapter = TypeAdapter(LicenseInfo)
-    errors: list[str] = []
+    publication_adapter = TypeAdapter(publication_cls)
+    license_info_adapter: TypeAdapter[LicenseInfo] = TypeAdapter(LicenseInfo)
+    errors = []
 
     log_capture = _setup_log_capture() if capture_warnings else None
 
-    info_urls: dict[int, str] = {
-        id(license_): info_url
-        for _, license_, info_url in iter_license_info_links(publications)
-    }
+    for publication_dict in publications:
+        if log_capture:
+            log_capture.clear()
 
-    for publication in publications:
-        for license_ in publication.get("licenses") or []:
+        try:
+            publication = publication_adapter.validate_python(publication_dict)
+
+            # Check for captured warnings during parsing
+            warnings = "".join(log_capture.get_messages()) if log_capture else None
+
+            if display_diff:
+                diff = "\n".join(_diff_original_parsed(publication_dict, publication))
+            else:
+                diff = None
+
+            if diff or warnings:
+                errors.extend(
+                    _publication_issues(
+                        publication_dict,
+                        url,
+                        warnings=warnings,
+                        diff=diff,
+                    )
+                )
+        except ValidationError as e:
+            if not _should_ignore_error(e, ignore_errors):
+                errors.extend(_publication_issues(publication_dict, url, errors=str(e)))
+
+        # Validate any embedded License Info Documents on this publication.
+        # Inert for plain OPDS 2 (no `licenses`) and for ODL feeds where the
+        # docs weren't fetched (no `license_document` key).
+        for license_ in publication_dict.get("licenses") or []:
             license_doc = license_.get(LICENSE_DOCUMENT_KEY)
             if license_doc is None:
                 continue
-
-            info_url = info_urls.get(id(license_), "<unknown>")
-
-            if log_capture:
-                log_capture.clear()
-
-            try:
-                parsed = license_info_adapter.validate_python(license_doc)
-
-                warnings = "".join(log_capture.get_messages()) if log_capture else None
-
-                if display_diff:
-                    diff_lines = list(
-                        context_diff(
-                            json.dumps(
-                                license_doc, indent=2, sort_keys=True
-                            ).splitlines(),
-                            json.dumps(
-                                parsed.model_dump(
-                                    mode="json",
-                                    exclude_unset=True,
-                                    by_alias=True,
-                                ),
-                                indent=2,
-                                sort_keys=True,
-                            ).splitlines(),
-                            fromfile="original",
-                            tofile="parsed",
-                            lineterm="",
-                        )
-                    )
-                    diff = "\n".join(diff_lines) if diff_lines else None
-                else:
-                    diff = None
-
-                if diff or warnings:
-                    errors.extend(
-                        _license_issues(
-                            publication,
-                            license_,
-                            license_doc,
-                            info_url,
-                            warnings=warnings,
-                            diff=diff,
-                        )
-                    )
-            except ValidationError as e:
-                if _should_ignore_error(e, ignore_errors):
-                    continue
-
-                errors.extend(
-                    _license_issues(
-                        publication,
-                        license_,
-                        license_doc,
-                        info_url,
-                        errors=str(e),
-                    )
+            errors.extend(
+                _validate_license_document(
+                    publication_dict,
+                    license_,
+                    license_doc,
+                    license_info_adapter,
+                    log_capture=log_capture,
+                    ignore_errors=ignore_errors,
+                    display_diff=display_diff,
                 )
+            )
 
     return errors
 

--- a/src/palace/tools/validation/opds.py
+++ b/src/palace/tools/validation/opds.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import textwrap
+from copy import deepcopy
 from difflib import context_diff
 from typing import Any
 
@@ -25,6 +26,16 @@ def _should_ignore_error(error: ValidationError, ignore_errors: list[str]) -> bo
             return True
 
     return False
+
+
+def _strip_embedded_license_documents(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Return a deep copy of ``data`` without embedded License Info Documents.
+    """
+    data = deepcopy(data)
+    for license_ in data.get("licenses") or []:
+        license_.pop(LICENSE_DOCUMENT_KEY, None)
+    return data
 
 
 def _diff_original_parsed(original: dict[str, Any], parsed: BaseModel) -> list[str]:
@@ -247,7 +258,11 @@ def validate_opds_publications(
             warnings = "".join(log_capture.get_messages()) if log_capture else None
 
             if display_diff:
-                diff = "\n".join(_diff_original_parsed(publication_dict, publication))
+                diff = "\n".join(
+                    _diff_original_parsed(
+                        _strip_embedded_license_documents(publication_dict), publication
+                    )
+                )
             else:
                 diff = None
 

--- a/tests/palace_tools/validation/test_opds.py
+++ b/tests/palace_tools/validation/test_opds.py
@@ -6,7 +6,12 @@ import pytest
 
 from palace.opds.opds2 import Publication
 
-from palace.tools.validation.opds import validate_opds_feeds, validate_opds_publications
+from palace.tools.feeds.odl import LICENSE_DOCUMENT_KEY, iter_license_info_links
+from palace.tools.validation.opds import (
+    validate_license_documents,
+    validate_opds_feeds,
+    validate_opds_publications,
+)
 
 
 class OpdsValidationFixture:
@@ -288,3 +293,198 @@ class TestValidateOpdsFeeds:
         )
 
         assert any(feed_url in e for e in errors)
+
+
+def _odl_publication(
+    *,
+    identifier: str = "urn:isbn:9999999999",
+    title: str = "Some ODL Book",
+    license_identifier: str = "license-1",
+    info_url: str = "https://example.com/licenses/1/info",
+    license_document: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """An OPDS2+ODL publication dict, optionally pre-loaded with a fetched License Info Document."""
+    license_dict: dict[str, Any] = {
+        "metadata": {
+            "identifier": license_identifier,
+            "format": "application/epub+zip",
+            "created": "2024-01-01T00:00:00Z",
+        },
+        "links": [
+            {
+                "rel": "self",
+                "href": info_url,
+                "type": "application/vnd.odl.info+json",
+            },
+            {
+                "rel": "http://opds-spec.org/acquisition/borrow",
+                "href": "https://example.com/licenses/1/checkout",
+                "type": "application/vnd.readium.license.status.v1.0+json",
+            },
+        ],
+    }
+    if license_document is not None:
+        license_dict[LICENSE_DOCUMENT_KEY] = license_document
+
+    return {
+        "metadata": {
+            "@type": "http://schema.org/Book",
+            "title": title,
+            "identifier": identifier,
+        },
+        "images": [{"href": "http://example.com/cover.jpg", "type": "image/jpeg"}],
+        "links": [
+            {
+                "href": "http://example.com/book.epub",
+                "type": "application/epub+zip",
+                "rel": "http://opds-spec.org/acquisition/open-access",
+            }
+        ],
+        "licenses": [license_dict],
+    }
+
+
+def _valid_license_info(identifier: str = "license-1") -> dict[str, Any]:
+    return {
+        "identifier": identifier,
+        "status": "available",
+        "checkouts": {"available": 5, "left": 10},
+    }
+
+
+class TestIterLicenseInfoLinks:
+    def test_yields_self_link_for_odl_publication(self) -> None:
+        publication = _odl_publication()
+
+        results = list(iter_license_info_links([publication]))
+
+        assert len(results) == 1
+        pub, license_, info_url = results[0]
+        assert pub is publication
+        assert license_ is publication["licenses"][0]
+        assert info_url == "https://example.com/licenses/1/info"
+
+    def test_skips_plain_opds2_publications(
+        self, opds_validation_fixture: OpdsValidationFixture
+    ) -> None:
+        plain_pub = opds_validation_fixture.valid_publication_dict()
+        odl_pub = _odl_publication()
+
+        results = list(iter_license_info_links([plain_pub, odl_pub]))
+
+        assert len(results) == 1
+        assert results[0][0] is odl_pub
+
+    def test_skips_license_without_self_info_link(self) -> None:
+        publication = _odl_publication()
+        publication["licenses"][0]["links"] = [
+            {
+                "rel": "http://opds-spec.org/acquisition/borrow",
+                "href": "https://example.com/licenses/1/checkout",
+                "type": "application/vnd.readium.license.status.v1.0+json",
+            }
+        ]
+
+        assert list(iter_license_info_links([publication])) == []
+
+    def test_skips_self_link_with_wrong_content_type(self) -> None:
+        publication = _odl_publication()
+        publication["licenses"][0]["links"][0]["type"] = "application/json"
+
+        assert list(iter_license_info_links([publication])) == []
+
+    def test_handles_empty_licenses_array(self) -> None:
+        publication = _odl_publication()
+        publication["licenses"] = []
+
+        assert list(iter_license_info_links([publication])) == []
+
+
+class TestValidateLicenseDocuments:
+    def test_valid_license_info_returns_no_errors(self) -> None:
+        publication = _odl_publication(license_document=_valid_license_info())
+
+        errors = validate_license_documents(
+            [publication],
+            ignore_errors=[],
+            display_diff=False,
+        )
+
+        assert errors == []
+
+    def test_invalid_license_info_returns_errors(self) -> None:
+        invalid = {"identifier": "license-1", "status": "available"}
+        publication = _odl_publication(license_document=invalid)
+
+        errors = validate_license_documents(
+            [publication],
+            ignore_errors=[],
+            display_diff=False,
+        )
+
+        assert len(errors) > 0
+        assert any("Validation failed for License Info Document" in e for e in errors)
+        assert any("License identifier: license-1" in e for e in errors)
+        assert any(
+            "Info-doc URL: https://example.com/licenses/1/info" in e for e in errors
+        )
+        assert any("Publication identifier: urn:isbn:9999999999" in e for e in errors)
+
+    def test_ignore_errors_filters_matching_errors(self) -> None:
+        invalid = {"identifier": "license-1", "status": "available"}
+        publication = _odl_publication(license_document=invalid)
+
+        errors = validate_license_documents(
+            [publication],
+            ignore_errors=["checkouts"],
+            display_diff=False,
+        )
+
+        assert errors == []
+
+    def test_publication_without_licenses_is_noop(
+        self, opds_validation_fixture: OpdsValidationFixture
+    ) -> None:
+        plain_pub = opds_validation_fixture.valid_publication_dict()
+
+        errors = validate_license_documents(
+            [plain_pub],
+            ignore_errors=[],
+            display_diff=False,
+        )
+
+        assert errors == []
+
+    def test_license_without_embedded_document_is_skipped(self) -> None:
+        publication = _odl_publication()  # no license_document set
+
+        errors = validate_license_documents(
+            [publication],
+            ignore_errors=[],
+            display_diff=False,
+        )
+
+        assert errors == []
+
+    def test_mixed_valid_invalid_license_docs(self) -> None:
+        valid_pub = _odl_publication(
+            identifier="urn:isbn:1111111111",
+            license_identifier="license-valid",
+            info_url="https://example.com/licenses/valid/info",
+            license_document=_valid_license_info("license-valid"),
+        )
+        invalid_pub = _odl_publication(
+            identifier="urn:isbn:2222222222",
+            license_identifier="license-invalid",
+            info_url="https://example.com/licenses/invalid/info",
+            license_document={"identifier": "license-invalid", "status": "available"},
+        )
+
+        errors = validate_license_documents(
+            [valid_pub, invalid_pub],
+            ignore_errors=[],
+            display_diff=False,
+        )
+
+        assert any("license-invalid" in e for e in errors)
+        assert not any("urn:isbn:1111111111" in e for e in errors)

--- a/tests/palace_tools/validation/test_opds.py
+++ b/tests/palace_tools/validation/test_opds.py
@@ -4,11 +4,11 @@ from typing import Any
 
 import pytest
 
+from palace.opds.odl.odl import Opds2OrOpds2WithOdlPublication
 from palace.opds.opds2 import Publication
 
 from palace.tools.feeds.odl import LICENSE_DOCUMENT_KEY, iter_license_info_links
 from palace.tools.validation.opds import (
-    validate_license_documents,
     validate_opds_feeds,
     validate_opds_publications,
 )
@@ -400,12 +400,16 @@ class TestIterLicenseInfoLinks:
         assert list(iter_license_info_links([publication])) == []
 
 
-class TestValidateLicenseDocuments:
+class TestLicenseDocumentValidation:
+    """Embedded License Info Document validation, exercised through
+    validate_opds_publications with the ODL publication class."""
+
     def test_valid_license_info_returns_no_errors(self) -> None:
         publication = _odl_publication(license_document=_valid_license_info())
 
-        errors = validate_license_documents(
+        errors = validate_opds_publications(
             [publication],
+            Opds2OrOpds2WithOdlPublication,
             ignore_errors=[],
             display_diff=False,
         )
@@ -416,8 +420,9 @@ class TestValidateLicenseDocuments:
         invalid = {"identifier": "license-1", "status": "available"}
         publication = _odl_publication(license_document=invalid)
 
-        errors = validate_license_documents(
+        errors = validate_opds_publications(
             [publication],
+            Opds2OrOpds2WithOdlPublication,
             ignore_errors=[],
             display_diff=False,
         )
@@ -434,8 +439,9 @@ class TestValidateLicenseDocuments:
         invalid = {"identifier": "license-1", "status": "available"}
         publication = _odl_publication(license_document=invalid)
 
-        errors = validate_license_documents(
+        errors = validate_opds_publications(
             [publication],
+            Opds2OrOpds2WithOdlPublication,
             ignore_errors=["checkouts"],
             display_diff=False,
         )
@@ -447,8 +453,9 @@ class TestValidateLicenseDocuments:
     ) -> None:
         plain_pub = opds_validation_fixture.valid_publication_dict()
 
-        errors = validate_license_documents(
+        errors = validate_opds_publications(
             [plain_pub],
+            Opds2OrOpds2WithOdlPublication,
             ignore_errors=[],
             display_diff=False,
         )
@@ -458,8 +465,9 @@ class TestValidateLicenseDocuments:
     def test_license_without_embedded_document_is_skipped(self) -> None:
         publication = _odl_publication()  # no license_document set
 
-        errors = validate_license_documents(
+        errors = validate_opds_publications(
             [publication],
+            Opds2OrOpds2WithOdlPublication,
             ignore_errors=[],
             display_diff=False,
         )
@@ -480,11 +488,56 @@ class TestValidateLicenseDocuments:
             license_document={"identifier": "license-invalid", "status": "available"},
         )
 
-        errors = validate_license_documents(
+        errors = validate_opds_publications(
             [valid_pub, invalid_pub],
+            Opds2OrOpds2WithOdlPublication,
             ignore_errors=[],
             display_diff=False,
         )
 
         assert any("license-invalid" in e for e in errors)
-        assert not any("urn:isbn:1111111111" in e for e in errors)
+        # The valid publication's metadata should never appear in errors.
+        assert not any(
+            "Publication identifier: urn:isbn:1111111111" in e for e in errors
+        )
+
+    def test_info_url_resolved_from_license_self_link(self) -> None:
+        """Info-doc URL in errors is read directly off the license's self link
+        (no separate URL map / id() lookup)."""
+        publication = _odl_publication(
+            info_url="https://example.com/licenses/custom/info",
+            license_document={"identifier": "license-1", "status": "available"},
+        )
+
+        errors = validate_opds_publications(
+            [publication],
+            Opds2OrOpds2WithOdlPublication,
+            ignore_errors=[],
+            display_diff=False,
+        )
+
+        assert any(
+            "Info-doc URL: https://example.com/licenses/custom/info" in e
+            for e in errors
+        )
+
+    def test_unknown_info_url_when_self_link_missing(self) -> None:
+        """If the license has no matching self link (e.g. doc was attached
+        manually for an offline check), the URL is reported as <unknown>."""
+        publication = _odl_publication(
+            license_document={"identifier": "license-1", "status": "available"}
+        )
+        publication["licenses"][0]["links"] = [
+            link
+            for link in publication["licenses"][0]["links"]
+            if link.get("rel") != "self"
+        ]
+
+        errors = validate_opds_publications(
+            [publication],
+            Opds2OrOpds2WithOdlPublication,
+            ignore_errors=[],
+            display_diff=False,
+        )
+
+        assert any("Info-doc URL: <unknown>" in e for e in errors)


### PR DESCRIPTION
## Description

Add support for fetching and validating OPDS 2 + ODL License Info Documents, and unify HTTP retry behavior across the feed clients.

- New `download-feed opds2-odl` command that downloads an OPDS2+ODL feed and (by default) fetches each license's License Info Document, embedding the parsed body under a `license_document` key on the license.
- `validate-feed opds2-odl` gains `--license-documents` / `--no-license-documents` and `--connections` flags; when enabled, License Info Documents are fetched and validated against the `LicenseInfo` schema.
- License Info Document validation is inline inside `validate_opds_publications` — every publication is validated against its publication class, and any embedded `license_document` is validated in the same pass. 
- New `feeds/retry.py` module shared by `opds.make_request`, `odl.fetch_license_documents`, and `overdrive.fetch`. Single retry policy: 4 total attempts, retries on `httpx.RequestError` / non-200 status / `JSONDecodeError`, consistent log format, `sys.exit(-1)` on terminal failure. opds and odl call the sync/async helpers directly; overdrive keeps its work-stealing structure but adopts the same `MAX_ATTEMPTS` and exception set inline.

## Motivation and Context

We need to be able to download and validate the License Info Documents referenced by OPDS2+ODL feeds — they're a separate document per license that the existing OPDS 2 tooling didn't touch.

## How Has This Been Tested?

- `pytest` — all 167 tests pass, including 6 rewritten license-doc validation tests that now drive the merged code path through `validate_opds_publications`, plus 2 new tests covering self-link URL resolution and the `<unknown>` fallback when no self link is present.
- `mypy` — clean on all modified modules.

## Checklist

- [X] I have updated the documentation accordingly.
- [x] All new and existing tests passed.