### PR TITLE
Add a global --version flag to all CLI entry points

### DIFF
--- a/src/palace/tools/utils/typer.py
+++ b/src/palace/tools/utils/typer.py
@@ -5,16 +5,38 @@ import sys
 import traceback
 from typing import Any
 
+import click
 import typer
+
+from palace.tools import __version__
+
+
+def _version_callback(ctx: click.Context, param: click.Parameter, value: bool) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(__version__ if __version__ is not None else "unknown")
+    ctx.exit()
 
 
 def run_typer_app_as_main(app: typer.Typer, *args: Any, **kwargs: Any) -> Any | None:
     """Run a typer app as the main function.
 
-    Catch any uncaught exceptions and print them to stderr.
+    Adds a global ``--version`` option to the app and catches any uncaught
+    exceptions, printing them to stderr.
     """
+    cmd = typer.main.get_command(app)
+    cmd.params.append(
+        click.Option(
+            ["--version"],
+            is_flag=True,
+            is_eager=True,
+            expose_value=False,
+            callback=_version_callback,
+            help="Show the version and exit.",
+        )
+    )
     try:
-        return app(*args, **kwargs)
+        return cmd(*args, **kwargs)
     except typer.Exit as e:
         sys.exit(e.exit_code)
     except Exception:


### PR DESCRIPTION
## Description

Adds a `--version` flag to every `palace-tools` CLI without per-command boilerplate. The flag is registered on the underlying Click command inside `run_typer_app_as_main`, so all 11 entry points routed through that helper gain `--version` automatically. Prints `palace.tools.__version__`, or `unknown` if the generated `_version.py` couldn't be imported.

## Motivation and Context

Previously there was no way to ask any of these tools which version was installed. Adding `--version` to each `@app.command` would mean touching every command in every CLI. Doing it via a top-level `app.callback()` would have changed how single-command apps (e.g. `palace-terminal`, `generate-demarque-keys`) are invoked. Adding the option directly to the resolved Click command sidesteps both problems.

## How Has This Been Tested?

- `mypy src/palace/tools/utils/typer.py` — passes
- `pytest -q` — 154 passed
- Multi-command app: `download-feed --version` prints version, `download-feed --help` still lists subcommands cleanly.
- Single-command apps: `generate-demarque-keys --version`, `fetch-lcp --version`, `stress-test-opds2 --version`, `validate-feed --version` all print version. Existing single-command invocation form is unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.