### PR TITLE
Add opds2-odl-publications validation command

### DIFF
--- a/src/palace/tools/cli/validate_feed.py
+++ b/src/palace/tools/cli/validate_feed.py
@@ -240,6 +240,56 @@ def validate_opds2_publications(
     )
 
 
+@app.command("opds2-odl-publications")
+def validate_opds2_odl_publications(
+    ignore: list[str] = typer.Option(
+        [],
+        help="Ignore these errors (Can be specified multiple times)",
+        metavar="ERROR",
+    ),
+    diff: bool = typer.Option(
+        False, "--diff", "-d", help="Show a diff between the parsed and original JSON."
+    ),
+    no_warnings: bool = typer.Option(
+        False, "--no-warnings", help="Disable capturing and displaying parser warnings."
+    ),
+    input_file: Path = typer.Argument(
+        ...,
+        help="File containing the feed to validate",
+        metavar="INPUT_FILE",
+        exists=True,
+        readable=True,
+        file_okay=True,
+        dir_okay=False,
+    ),
+    output_file: Path = typer.Argument(
+        None,
+        help="Output the validation results to a file. If not given, the results will be printed to stdout.",
+        metavar="OUTPUT_FILE",
+        writable=True,
+        file_okay=True,
+        dir_okay=False,
+    ),
+) -> None:
+    """Validate OPDS 2 + ODL publications from a file.
+
+    The file should contain an array of publication objects, like the "publications" field in an OPDS 2 + ODL feed.
+    This matches the format output by the `download-feed opds2-odl` command, including any License Info Documents
+    embedded under the "license_document" key.
+    """
+    with input_file.open("r") as file:
+        data = json.load(file)
+    validate(
+        output_file,
+        validate_opds_publications,
+        data,
+        odl_models.Opds2OrOpds2WithOdlPublication,
+        ignore_errors=ignore,
+        display_diff=diff,
+        capture_warnings=not no_warnings,
+    )
+
+
 def main() -> None:
     run_typer_app_as_main(app, prog_name="validate-feed")
 

--- a/tests/palace_tools/cli/test_validate_feed.py
+++ b/tests/palace_tools/cli/test_validate_feed.py
@@ -1,0 +1,150 @@
+"""Tests for the validate_feed CLI tool."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from palace.tools.cli.validate_feed import app
+from palace.tools.feeds.odl import LICENSE_DOCUMENT_KEY
+
+runner = CliRunner()
+
+
+def _odl_publication(
+    *,
+    identifier: str = "urn:isbn:9999999999",
+    title: str = "Some ODL Book",
+    license_identifier: str = "license-1",
+    info_url: str = "https://example.com/licenses/1/info",
+    license_document: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """An OPDS2+ODL publication dict, optionally with an embedded License Info Document."""
+    license_dict: dict[str, Any] = {
+        "metadata": {
+            "identifier": license_identifier,
+            "format": "application/epub+zip",
+            "created": "2024-01-01T00:00:00Z",
+        },
+        "links": [
+            {
+                "rel": "self",
+                "href": info_url,
+                "type": "application/vnd.odl.info+json",
+            },
+            {
+                "rel": "http://opds-spec.org/acquisition/borrow",
+                "href": "https://example.com/licenses/1/checkout",
+                "type": "application/vnd.readium.license.status.v1.0+json",
+            },
+        ],
+    }
+    if license_document is not None:
+        license_dict[LICENSE_DOCUMENT_KEY] = license_document
+
+    return {
+        "metadata": {
+            "@type": "http://schema.org/Book",
+            "title": title,
+            "identifier": identifier,
+        },
+        "images": [{"href": "http://example.com/cover.jpg", "type": "image/jpeg"}],
+        "links": [
+            {
+                "href": "http://example.com/book.epub",
+                "type": "application/epub+zip",
+                "rel": "http://opds-spec.org/acquisition/open-access",
+            }
+        ],
+        "licenses": [license_dict],
+    }
+
+
+def _valid_license_info(identifier: str = "license-1") -> dict[str, Any]:
+    return {
+        "identifier": identifier,
+        "status": "available",
+        "checkouts": {"available": 5, "left": 10},
+    }
+
+
+def _write_publications(path: Path, publications: list[dict[str, Any]]) -> Path:
+    path.write_text(json.dumps(publications))
+    return path
+
+
+class TestValidateOpds2OdlPublications:
+    """Tests for the opds2-odl-publications command."""
+
+    def test_help(self) -> None:
+        result = runner.invoke(app, ["opds2-odl-publications", "--help"])
+        assert result.exit_code == 0
+        assert "OPDS 2 + ODL publications from a file" in result.output
+
+    def test_valid_publications_succeed(self, tmp_path: Path) -> None:
+        input_file = _write_publications(
+            tmp_path / "pubs.json",
+            [_odl_publication(license_document=_valid_license_info())],
+        )
+
+        result = runner.invoke(app, ["opds2-odl-publications", str(input_file)])
+
+        assert result.exit_code == 0
+        assert "Success! No validation errors found." in result.output
+
+    def test_invalid_license_document_reports_error(self, tmp_path: Path) -> None:
+        input_file = _write_publications(
+            tmp_path / "pubs.json",
+            [
+                _odl_publication(
+                    license_document={"identifier": "license-1", "status": "available"}
+                )
+            ],
+        )
+
+        result = runner.invoke(app, ["opds2-odl-publications", str(input_file)])
+
+        assert result.exit_code == 0
+        assert "Validation failed for License Info Document" in result.output
+        assert "Info-doc URL: https://example.com/licenses/1/info" in result.output
+
+    def test_ignore_filters_matching_errors(self, tmp_path: Path) -> None:
+        input_file = _write_publications(
+            tmp_path / "pubs.json",
+            [
+                _odl_publication(
+                    license_document={"identifier": "license-1", "status": "available"}
+                )
+            ],
+        )
+
+        result = runner.invoke(
+            app,
+            ["opds2-odl-publications", "--ignore", "checkouts", str(input_file)],
+        )
+
+        assert result.exit_code == 0
+        assert "Success! No validation errors found." in result.output
+
+    def test_errors_written_to_output_file(self, tmp_path: Path) -> None:
+        input_file = _write_publications(
+            tmp_path / "pubs.json",
+            [
+                _odl_publication(
+                    license_document={"identifier": "license-1", "status": "available"}
+                )
+            ],
+        )
+        output_file = tmp_path / "results.txt"
+
+        result = runner.invoke(
+            app,
+            ["opds2-odl-publications", str(input_file), str(output_file)],
+        )
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+        assert "Validation failed for License Info Document" in output_file.read_text()


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Adds a new `opds2-odl-publications` command to `validate-feed`, mirroring the existing `opds2-publications` command but validating against the OPDS 2 + ODL publication model (`Opds2OrOpds2WithOdlPublication`) instead of `opds2.Publication`.

The command reads a JSON file containing an array of publication objects — matching the format produced by `download-feed opds2-odl` — and validates each publication. Because it routes through the existing `validate_opds_publications` function, it also validates any License Info Documents embedded under the `license_document` key. It supports the same `--ignore`, `--diff`, `--no-warnings`, input-file, and optional output-file arguments as the other file-based validation commands.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`validate-feed` could validate an array of plain OPDS 2 publications from a file (`opds2-publications`), but there was no file-based equivalent for OPDS 2 + ODL publications. This adds that missing counterpart so ODL publications downloaded via `download-feed opds2-odl` can be validated offline, including their embedded License Info Documents.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added `tests/palace_tools/cli/test_validate_feed.py` covering the new command: help text, valid publications succeeding, invalid embedded license documents being reported, the `--ignore` filter, and writing errors to an output file.
- Ran the full test suite (`pytest tests`) — 175 passed.
- Ran `mypy` and `pre-commit run --all-files` on the changed files — no issues.
- Manually verified end-to-end against a sample file: a valid ODL publication reports "Success!", a publication with an invalid embedded license document reports the License Info Document error with the correct identifiers/URL, and `--ignore checkouts` filters that error back to success.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
